### PR TITLE
User creates new charity

### DIFF
--- a/app/controllers/charities_controller.rb
+++ b/app/controllers/charities_controller.rb
@@ -1,7 +1,7 @@
 class CharitiesController < ApplicationController
 
   def index
-    @charities = Charity.all
+    @charities = Charity.online_charities
   end
 
   def show
@@ -35,16 +35,16 @@ class CharitiesController < ApplicationController
   end
 
   def create
-    #staus will be default 0 --> pending, 1 --> online, 2 --> offline
-    charity = Charity.new(name: params[:charity][:name],
+    @charity = Charity.new(name: params[:charity][:name],
                           description: params[:charity][:description],
                           status: 0)
-    if charity.save
+    if @charity.save
       flash[:success] = "Your charity request has been recieved.
         Once it has been approved it will be visible on our site."
       redirect_to charities_path
     else
-      #sad path here --> write a new test for this
+      flash[:error] = "Make sure you have filled in both name and description."
+      redirect_to new_charity_path
     end
   end
 

--- a/app/controllers/charities_controller.rb
+++ b/app/controllers/charities_controller.rb
@@ -25,6 +25,29 @@ class CharitiesController < ApplicationController
     end
   end
 
+  def new
+    if current_user
+      @charity = Charity.new
+    else
+      flash[:error] = "You must be logged in to create a new charity"
+      redirect_to charities_path
+    end
+  end
+
+  def create
+    #staus will be default 0 --> pending, 1 --> online, 2 --> offline
+    charity = Charity.new(name: params[:charity][:name],
+                          description: params[:charity][:description],
+                          status: 0)
+    if charity.save
+      flash[:success] = "Your charity request has been recieved.
+        Once it has been approved it will be visible on our site."
+      redirect_to charities_path
+    else
+      #sad path here --> write a new test for this
+    end
+  end
+
   private
     def charity_params
       params.require(:charity).permit(:name,

--- a/app/models/charity.rb
+++ b/app/models/charity.rb
@@ -9,7 +9,13 @@ class Charity < ActiveRecord::Base
   has_many :users, through: :user_roles
   has_many :roles, through: :user_roles
 
+  enum status: %w(pending online offline)
+  
   def create_slug
     self.slug = self.name.parameterize
+  end
+
+  def self.online_charities
+    where(status: 1)
   end
 end

--- a/app/views/charities/index.html.erb
+++ b/app/views/charities/index.html.erb
@@ -5,3 +5,7 @@
     <li><%= link_to charity.name, charity_path(charity.slug) %></li>
   <% end %>
 </ul>
+
+<% if current_user %>
+  <%= button_to "Apply To Be One of Our Charities", new_charity_path, method: :get %>
+<% end %>

--- a/app/views/charities/new.html.erb
+++ b/app/views/charities/new.html.erb
@@ -1,4 +1,4 @@
-<h1>Edit A Charity</h1>
+<h1>Create a New Charity</h1>
 
 <%= form_for @charity, url: "/charities/#{@charity.id}" do |f| %>
   <div class="form-group">
@@ -11,11 +11,6 @@
     <%= f.text_area :description, class: "form-control" %>
   </div>
 
-  <div class="form-group">
-    <%= f.label :status, "Status" %>
-    <%= f.select :status, options_for_select(["online", "pending", "offline"]), {}, class: "small-search", style: "margin-left: 64px;" %><br>
-  </div>
-
-  <%= f.submit "Update Charity", class: "btn btn-warning" %>
+  <%= f.submit "Create Charity", class: "btn btn-warning" %>
 
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
     resource :dashboard, only: [:show]
     resources :families, only: [:show, :new, :create, :index, :update]
   end
-#this will be namspaced underneath the charity
+
   resources :families, only: [:index, :show]
 
   resources :users, only: [:new, :create, :edit, :update]
@@ -21,11 +21,10 @@ Rails.application.routes.draw do
   resources :donations, only: [:index, :show, :new, :create]
 
   resources :loans, only: [:show, :edit, :update, :new, :create]
-  # resources :homes, only: [:show]
 
   root to: "homes#show"
 
-  resources :charities, only: [:index, :edit]
+  resources :charities, only: [:index, :edit, :new, :create]
   patch '/charities/:id', to: "charities#update"
 
   get ':charity_slug', to: 'charities#show', as: :charity

--- a/spec/features/user_can_create_a_new_charity_spec.rb
+++ b/spec/features/user_can_create_a_new_charity_spec.rb
@@ -19,6 +19,29 @@ RSpec.feature "User creates new charity" do
 
       expect(page).to have_content("Your charity request has been recieved.
                     Once it has been approved it will be visible on our site.")
+
+      expect(page).to_not have_content("Charity Name")
+      expect(page).to_not have_content("Description of our new charity.")
+    end
+  end
+
+  context "logged in user is not successful" do
+    scenario "they do not fill in name field and cannot create their charity" do
+      user = create(:user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return( user )
+
+      visit charities_path
+
+      click_button "Apply To Be One of Our Charities"
+
+      expect(page).to have_content("Create a New Charity")
+      expect(current_path).to eq(new_charity_path)
+
+      fill_in "Description", with: "Description of our new charity."
+      click_on "Create Charity"
+
+      expect(page).to have_content("Make sure you have filled in both name and description.")
+      expect(current_path).to eq(new_charity_path)
     end
   end
 

--- a/spec/features/user_can_create_a_new_charity_spec.rb
+++ b/spec/features/user_can_create_a_new_charity_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.feature "User creates new charity" do
+  context "user is logged in" do
+    scenario "user successfully creates new charity" do
+      user = create(:user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return( user )
+
+      visit charities_path
+
+      click_button "Apply To Be One of Our Charities"
+
+      expect(page).to have_content("Create a New Charity")
+      expect(current_path).to eq(new_charity_path)
+
+      fill_in "Name", with: "Charity Name"
+      fill_in "Description", with: "Description of our new charity."
+      click_on "Create Charity"
+
+      expect(page).to have_content("Your charity request has been recieved.
+                    Once it has been approved it will be visible on our site.")
+    end
+  end
+
+  context "user is not logged in" do
+    scenario "user cannot see an option to create a charity" do
+      user = create(:user)
+
+      visit charities_path
+
+      expect(page).to_not have_button("Apply To Be One of Our Charities")
+    end
+  end
+end


### PR DESCRIPTION
A logged in user can create a new charity that will default to the status of pending. Only online charities will be displayed. A user does not have the option to create a charity unless they are logged in.
